### PR TITLE
Locking for a safe data sharing between threads

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -16,6 +16,7 @@ import math
 import random
 import time
 import unittest
+import threading
 
 from ratelimiter import RateLimiter
 
@@ -57,9 +58,16 @@ class TestBasic(unittest.TestCase):
     def test_limit_1(self):
         with Timer() as timer:
             obj = RateLimiter(self.max_calls, self.period)
-            for i in range(11):
+            for i in range(self.max_calls + 1):
                 with obj:
+                    # After the 'self.max_calls' iteration the execution 
+                    # inside the context manager should be blocked 
+                    # for the 'self.period' seconds.
                     pass
+        # The sum of the time in the iterations without the rate limit blocking
+        # is way lower than 'self.period'. If the duration of the all 
+        # iterations is greater or equal to the 'self.period' then blocking 
+        # and sleeping after the 'self.max_calls' iteration has been occured.
         self.assertGreaterEqual(timer.duration, self.period)
 
     def test_limit_2(self):
@@ -75,11 +83,17 @@ class TestBasic(unittest.TestCase):
     def test_decorator_1(self):
         @RateLimiter(self.max_calls, self.period)
         def f():
+            # After the 'self.max_calls' iteration the execution 
+            # of the function should be blocked for the 'self.period' seconds.
             pass
 
         with Timer() as timer:
-            [f() for i in range(11)]
+            [f() for i in range(self.max_calls + 1)]
 
+        # The sum of the time in the iterations without the rate limit blocking
+        # is way lower than 'self.period'. If the duration of the all 
+        # iterations is greater or equal to the 'self.period' then blocking 
+        # and sleeping after the 'self.max_calls' iteration has been occured.
         self.assertGreaterEqual(timer.duration, self.period)
 
     def test_decorator_2(self):
@@ -102,6 +116,29 @@ class TestBasic(unittest.TestCase):
                     calls.append(time.time())
 
             self.validate_call_times(calls, self.max_calls, self.period)
+
+    def test_threading(self):
+        @RateLimiter(self.max_calls, self.period)
+        def f():
+            # After the 'self.max_calls' iteration the execution 
+            # of the function should be blocked for the 'self.period' seconds.
+            pass
+
+        with Timer() as timer:
+            threads = []
+            for i in range(self.max_calls + 1):
+                # Running each target in it's own thread should not affect 
+                # the rate limiting
+                t = threading.Thread(target=f)
+                threads.append(t)
+                t.start()
+            [t.join() for t in threads]
+
+        # The sum of the time in the iterations without the rate limit blocking
+        # is way lower than 'self.period'. If the duration of the all 
+        # iterations is greater or equal to the 'self.period' then blocking 
+        # and sleeping after the 'self.max_calls' iteration has been occured.
+        self.assertGreaterEqual(timer.duration, self.period)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi. I've added locking for safe data sharing between threads.

For example:

```python
@RateLimiter(self.max_calls, self.period)
def f(i):
    # emulate some IO latency
    time.sleep(random.uniform(self.period / 2, self.period))
    
threads = []
for i in range(100000000):
    threads.append(threading.Thread(target=f, args=(i,)))
    threads[-1].start()
[t.join() for t in threads]
```

In some circumstances the code above can raise errors like this:
```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/Users/web-chib/develop/ratelimiter/ratelimiter/__init__.py", line 63, in wrapped
    return f(*args, **kwargs)
  File "/Users/web-chib/develop/ratelimiter/ratelimiter/__init__.py", line 87, in __exit__
    while self._timespan >= self.period:
  File "/Users/web-chib/develop/ratelimiter/ratelimiter/__init__.py", line 119, in _timespan
    return self.calls[-1] - self.calls[0]
IndexError: deque index out of range
```