### PR TITLE
Split async code to a separate module.

### DIFF
--- a/ratelimiter/__init__.py
+++ b/ratelimiter/__init__.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Original work Copyright 2013 Arnaud Porterie
+# Modified work Copyright 2016 Frazer McLean
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+__author__ = 'Frazer McLean <frazer@frazermclean.co.uk>'
+__version__ = '1.2.0.post0'
+__license__ = 'Apache'
+__description__ = 'Simple python rate limiting object'
+
+# Async support is provided only on Python 3.5+
+if sys.version_info >= (3, 5):
+    from .async import AsyncRateLimiter as RateLimiter
+else:
+    from .sync import RateLimiter
+
+__all__ = [
+    "RateLimiter",
+]

--- a/ratelimiter/async.py
+++ b/ratelimiter/async.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Async support for 3.5+ """
+
+import time
+import asyncio
+
+from .sync import RateLimiter
+
+
+class AsyncRateLimiter(RateLimiter):
+
+    def _init_async_lock(self):
+        with self._init_lock:
+            if self._alock is None:
+                self._alock = asyncio.Lock()
+
+    async def __aenter__(self):
+        if self._alock is None:
+            self._init_async_lock()
+
+        with await self._alock:
+            # We want to ensure that no more than max_calls were run in the allowed
+            # period. For this, we store the last timestamps of each call and run
+            # the rate verification upon each __enter__ call.
+            if len(self.calls) >= self.max_calls:
+                until = time.time() + self.period - self._timespan
+                if self.callback:
+                    asyncio.ensure_future(self.callback(until))
+                sleeptime = until - time.time()
+                if sleeptime > 0:
+                    await asyncio.sleep(sleeptime)
+            return self
+
+    __aexit__ = asyncio.coroutine(RateLimiter.__exit__)

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import setup
 import re
+from setuptools import setup
 
-FILE = 'ratelimiter.py'
+FILE = 'ratelimiter/__init__.py'
 init_data = open(FILE).read()
 
 metadata = dict(re.findall("__([a-z]+)__ = '([^']+)'", init_data))
@@ -44,7 +44,7 @@ setup(
     author=AUTHOR,
     author_email=EMAIL,
     url='https://github.com/RazerM/ratelimiter',
-    py_modules=['ratelimiter'],
+    packages=['ratelimiter'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: Apache Software License',

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -3,7 +3,7 @@ import pytest
 from ratelimiter import RateLimiter
 
 @pytest.mark.asyncio
-async def test_alock():
+async def test_alock(event_loop):
     rl = RateLimiter(max_calls=10, period=0.01)
 
     assert rl._alock is None


### PR DESCRIPTION
Remove exec.

I ended up creating an `AsyncRateLimiter` class that inherits from `RateLimiter` and adds the needed methods. Feels cleaner this way, but if you have any objections, please let me know.

Fixes #5 