### PR TITLE
async w/ python 3.8 compatibility sans warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install: # No dependencies
 script:
   - pip install -U pip setuptools

--- a/ratelimiter/__init__.py
+++ b/ratelimiter/__init__.py
@@ -17,7 +17,7 @@
 import sys
 
 __author__ = 'Frazer McLean <frazer@frazermclean.co.uk>'
-__version__ = '1.2.0.post0'
+__version__ = '1.2.0.post1'
 __license__ = 'Apache'
 __description__ = 'Simple python rate limiting object'
 

--- a/ratelimiter/_async.py
+++ b/ratelimiter/_async.py
@@ -19,7 +19,7 @@ class AsyncRateLimiter(RateLimiter):
         if self._alock is None:
             self._init_async_lock()
 
-        with await self._alock:
+        async with self._alock:
             # We want to ensure that no more than max_calls were run in the allowed
             # period. For this, we store the last timestamps of each call and run
             # the rate verification upon each __enter__ call.
@@ -32,4 +32,5 @@ class AsyncRateLimiter(RateLimiter):
                     await asyncio.sleep(sleeptime)
             return self
 
-    __aexit__ = asyncio.coroutine(RateLimiter.__exit__)
+    async def __aexit__(self, exc_type, exc_value, traceback):
+         return super(AsyncRateLimiter, self).__exit__(exc_type, exc_value, traceback)


### PR DESCRIPTION
this closes #10  by using async syntax that doesn't trigger warnings.

this pr also removes from travis the versions of python3 that are end of life'd (3.3, 3.4) adds the newer ones (3.7, 3.8) and increments the version (post0->post1) for release to pypi.