### PR TITLE
Fix pytest 7.x compatibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import sys
 import pytest
 
 
-class DummyCollector(pytest.collect.File):
+class DummyCollector(pytest.File):
     def collect(self):
         return []
 


### PR DESCRIPTION
`pytest.collect.File` was moved to `pytest.File` in pytest 7

It turns out that `pytest.File` was already available in all versions of pytest this project claims to support, so the change is backwards-compatible.