### PR TITLE
fix for python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.poetry]
+name = "ratelimiter"
+version = "1.2.0"
+description = "A rate-limiting library"
+authors = ["Frazer McLean <frazer@frazermclean.co.uk>"]

--- a/ratelimiter/_async.py
+++ b/ratelimiter/_async.py
@@ -32,4 +32,5 @@ class AsyncRateLimiter(RateLimiter):
                     await asyncio.sleep(sleeptime)
             return self
 
-    __aexit__ = asyncio.coroutine(RateLimiter.__exit__)
+    # backward behavior for python 3.5 - 3.10; no need for decorator if deprecated in python > 3.11
+    __aexit__ = asyncio.coroutine(RateLimiter.__exit__) if hasattr(asyncio, 'coroutine') else RateLimiter.__exit__


### PR DESCRIPTION
backward behavior for python 3.5 - 3.10; no need for decorator if deprecated in python >= 3.11